### PR TITLE
Add default to match expression in LoanResources

### DIFF
--- a/app/Filament/Resources/LoanResource.php
+++ b/app/Filament/Resources/LoanResource.php
@@ -195,6 +195,7 @@ class LoanResource extends Resource
                         'fully_paid' => 'success',
                         'denied' => 'danger',
                         'defaulted' => 'warning',
+                        default => 'warning',
                     })
                     ->searchable(),
                 Tables\Columns\TextColumn::make('principal_amount')


### PR DESCRIPTION
An exception is thrown when there's no default branch for the match expression